### PR TITLE
Stop triggering build when not in play view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED] - YYYY-MM-DD
+
+### Fixed
+
+-   [#10](https://github.com/equinor/webviz-config-editor/pull/10) - Fixed: Build was automatically triggered when opening/editing an existing config file. Now it is only triggered when opening the `Play` view.

--- a/src/services/webviz-build-service.tsx
+++ b/src/services/webviz-build-service.tsx
@@ -83,7 +83,11 @@ export const WebvizBuildService: React.FC = props => {
     };
 
     React.useEffect(() => {
-        if (!currentFile || !currentFile.associatedWithFile) {
+        if (
+            !currentFile ||
+            !currentFile.associatedWithFile ||
+            currentView !== Pages.Play
+        ) {
             return;
         }
         const tempPath = createTempFilePath(path.dirname(activeFilePath));
@@ -105,7 +109,7 @@ export const WebvizBuildService: React.FC = props => {
             }
         };
         /* eslint-disable react-hooks/exhaustive-deps */
-    }, [activeFilePath]);
+    }, [activeFilePath, currentView]);
 
     React.useEffect(() => {
         const data = ipcRenderer.sendSync("get-app-data");
@@ -115,10 +119,6 @@ export const WebvizBuildService: React.FC = props => {
     }, []);
 
     React.useEffect(() => {
-        if (currentView !== Pages.Play) {
-            return;
-        }
-
         if (!currentFile || !currentFile.associatedWithFile) {
             setBuilderState(WebvizBuildState.UnsavedFile);
             return;
@@ -208,7 +208,7 @@ export const WebvizBuildService: React.FC = props => {
             removeWebvizTokenFile(tokenPath);
         };
         /* eslint-disable react-hooks/exhaustive-deps */
-    }, [tempFilePath, currentView]);
+    }, [tempFilePath]);
 
     React.useEffect(() => {
         if (currentFile?.editorValue) {
@@ -216,7 +216,7 @@ export const WebvizBuildService: React.FC = props => {
                 fs.writeFileSync(tempFilePath, currentFile.editorValue);
             }
         }
-    }, [currentFile?.editorValue, tempFilePath]);
+    }, [currentFile?.editorValue, tempFilePath, currentView]);
 
     return (
         <WebvizBuildServiceContextProvider

--- a/src/services/webviz-build-service.tsx
+++ b/src/services/webviz-build-service.tsx
@@ -10,6 +10,7 @@ import {useAppDispatch, useAppSelector} from "@redux/hooks";
 import {addNotification} from "@redux/reducers/notifications";
 
 import {NotificationType} from "@shared-types/notifications";
+import {Pages} from "@shared-types/ui";
 
 import fs from "fs";
 import path from "path";
@@ -52,6 +53,7 @@ export const WebvizBuildService: React.FC = props => {
     const currentFile = useAppSelector(state =>
         state.files.files.find(file => file.filePath === state.files.activeFile)
     );
+    const currentView = useAppSelector(state => state.ui.currentPage);
     const webvizTheme = useAppSelector(state => state.preferences.webvizTheme);
     const pythonInterpreterPath = useAppSelector(
         state => state.preferences.pathToPythonInterpreter
@@ -113,6 +115,10 @@ export const WebvizBuildService: React.FC = props => {
     }, []);
 
     React.useEffect(() => {
+        if (currentView !== Pages.Play) {
+            return;
+        }
+
         if (!currentFile || !currentFile.associatedWithFile) {
             setBuilderState(WebvizBuildState.UnsavedFile);
             return;
@@ -202,7 +208,7 @@ export const WebvizBuildService: React.FC = props => {
             removeWebvizTokenFile(tokenPath);
         };
         /* eslint-disable react-hooks/exhaustive-deps */
-    }, [tempFilePath]);
+    }, [tempFilePath, currentView]);
 
     React.useEffect(() => {
         if (currentFile?.editorValue) {
@@ -210,7 +216,7 @@ export const WebvizBuildService: React.FC = props => {
                 fs.writeFileSync(tempFilePath, currentFile.editorValue);
             }
         }
-    }, [currentFile, tempFilePath]);
+    }, [currentFile?.editorValue, tempFilePath]);
 
     return (
         <WebvizBuildServiceContextProvider


### PR DESCRIPTION
Fixed: Build was automatically triggered when opening/editing an existing config file. Now it is only triggered when opening the `Play` view.

Closes #8.