### PR TITLE
Removed warning when not on Mac and switched from deprecated `uuid4` to `uuid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED] - YYYY-MM-DD
+
+## Changed
+
+- [#12](https://github.com/equinor/webviz-config-editor/pull/12) - Added a check if on Mac before running terminal command in order to prevent misleading error message on other OSes. Also switched from deprecated `uuidv4` to `uuid.v4`.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -215,6 +215,8 @@ const openApplication = async () => {
 
 openApplication();
 
-terminal()
-    // eslint-disable-next-line no-console
-    .catch(e => console.log(e));
+if (process.platform === 'darwin') {
+    terminal()
+        // eslint-disable-next-line no-console
+        .catch(e => console.log(e));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
                 "shelljs": "0.8.5",
                 "strip-ansi": "6.0.1",
                 "type-fest": "2.8.0",
-                "uuidv4": "^6.2.12",
+                "uuid": "^8.3.2",
                 "web-vitals": "2.1.2",
                 "which": "^2.0.2",
                 "yaml": "2.0.0-9"
@@ -82,6 +82,7 @@
                 "@types/redux-logger": "3.0.9",
                 "@types/shelljs": "0.8.9",
                 "@types/styled-components": "5.1.12",
+                "@types/uuid": "^8.3.4",
                 "@types/which": "^2.0.1",
                 "@typescript-eslint/eslint-plugin": "^4.14.2",
                 "@typescript-eslint/parser": "^4.0.0",
@@ -4883,8 +4884,7 @@
         "node_modules/@types/flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/@types/flat/-/flat-5.0.2.tgz",
-            "integrity": "sha512-3zsplnP2djeps5P9OyarTxwRpMLoe5Ash8aL9iprw0JxB+FAHjY+ifn4yZUuW4/9hqtnmor6uvjSRzJhiVbrEQ==",
-            "dev": true
+            "integrity": "sha512-3zsplnP2djeps5P9OyarTxwRpMLoe5Ash8aL9iprw0JxB+FAHjY+ifn4yZUuW4/9hqtnmor6uvjSRzJhiVbrEQ=="
         },
         "node_modules/@types/fs-extra": {
             "version": "9.0.13",
@@ -4996,8 +4996,7 @@
         "node_modules/@types/lodash": {
             "version": "4.14.178",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-            "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
-            "dev": true
+            "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
         },
         "node_modules/@types/luxon": {
             "version": "2.0.5",
@@ -5246,9 +5245,10 @@
             "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
         },
         "node_modules/@types/uuid": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
-            "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg=="
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true
         },
         "node_modules/@types/verror": {
             "version": "1.10.5",
@@ -5828,6 +5828,8 @@
             "version": "8.9.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
             "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -5842,7 +5844,9 @@
         "node_modules/ajv-formats/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "optional": true,
+            "peer": true
         },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
@@ -32334,15 +32338,6 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-        "node_modules/uuidv4": {
-            "version": "6.2.12",
-            "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.12.tgz",
-            "integrity": "sha512-UnN4ThIYWhv3ZUE8UwDnnCvh4JafCNu+sQkxmLyjCVwK3rjLfkg3DYiEv6oCMDIAIVEDP4INg4kX/C5hKaRzZA==",
-            "dependencies": {
-                "@types/uuid": "8.3.1",
-                "uuid": "8.3.2"
-            }
-        },
         "node_modules/uvu": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.3.tgz",
@@ -38150,8 +38145,7 @@
         "@types/flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/@types/flat/-/flat-5.0.2.tgz",
-            "integrity": "sha512-3zsplnP2djeps5P9OyarTxwRpMLoe5Ash8aL9iprw0JxB+FAHjY+ifn4yZUuW4/9hqtnmor6uvjSRzJhiVbrEQ==",
-            "dev": true
+            "integrity": "sha512-3zsplnP2djeps5P9OyarTxwRpMLoe5Ash8aL9iprw0JxB+FAHjY+ifn4yZUuW4/9hqtnmor6uvjSRzJhiVbrEQ=="
         },
         "@types/fs-extra": {
             "version": "9.0.13",
@@ -38263,8 +38257,7 @@
         "@types/lodash": {
             "version": "4.14.178",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-            "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
-            "dev": true
+            "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
         },
         "@types/luxon": {
             "version": "2.0.5",
@@ -38512,9 +38505,10 @@
             "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
         },
         "@types/uuid": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
-            "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg=="
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true
         },
         "@types/verror": {
             "version": "1.10.5",
@@ -38970,14 +38964,13 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-            "requires": {
-                "ajv": "^8.0.0"
-            },
+            "requires": {},
             "dependencies": {
                 "ajv": {
-                    "version": "8.9.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+                    "version": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
                     "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -38988,7 +38981,9 @@
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+                    "optional": true,
+                    "peer": true
                 }
             }
         },
@@ -59561,15 +59556,6 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        },
-        "uuidv4": {
-            "version": "6.2.12",
-            "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.12.tgz",
-            "integrity": "sha512-UnN4ThIYWhv3ZUE8UwDnnCvh4JafCNu+sQkxmLyjCVwK3rjLfkg3DYiEv6oCMDIAIVEDP4INg4kX/C5hKaRzZA==",
-            "requires": {
-                "@types/uuid": "8.3.1",
-                "uuid": "8.3.2"
-            }
         },
         "uvu": {
             "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "@types/redux-logger": "3.0.9",
         "@types/shelljs": "0.8.9",
         "@types/styled-components": "5.1.12",
+        "@types/uuid": "^8.3.4",
         "@types/which": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^4.14.2",
         "@typescript-eslint/parser": "^4.0.0",
@@ -120,7 +121,7 @@
         "shelljs": "0.8.5",
         "strip-ansi": "6.0.1",
         "type-fest": "2.8.0",
-        "uuidv4": "^6.2.12",
+        "uuid": "^8.3.2",
         "web-vitals": "2.1.2",
         "which": "^2.0.2",
         "yaml": "2.0.0-9"

--- a/src/components/Editor/editor.tsx
+++ b/src/components/Editor/editor.tsx
@@ -45,7 +45,7 @@ import {Environment, Uri, languages} from "monaco-editor";
 import "monaco-yaml/lib/esm/monaco.contribution";
 // @ts-ignore
 import * as path from "path";
-import {uuid} from "uuidv4";
+import {v4} from "uuid";
 // @ts-ignore
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import EditorWorker from "worker-loader!monaco-editor/esm/vs/editor/editor.worker";
@@ -532,7 +532,7 @@ export const Editor: React.FC<EditorProps> = () => {
                             <div
                                 className="Issue"
                                 onClick={() => selectMarker(marker)}
-                                key={uuid()}
+                                key={v4()}
                             >
                                 {marker.severity ===
                                 monaco.MarkerSeverity.Error ? (

--- a/src/services/webviz-build-service.tsx
+++ b/src/services/webviz-build-service.tsx
@@ -14,7 +14,7 @@ import {NotificationType} from "@shared-types/notifications";
 import fs from "fs";
 import path from "path";
 import {Options, PythonShell, PythonShellError} from "python-shell";
-import {uuid} from "uuidv4";
+import {v4} from "uuid";
 
 export enum WebvizBuildState {
     Loading = "loading",
@@ -34,7 +34,7 @@ type Context = {
 const createTempFilePath = (dir: string): string => {
     let tempPath = "";
     while (tempPath === "" || fs.existsSync(tempPath)) {
-        tempPath = path.resolve(dir, `.~${uuid()}.yaml`);
+        tempPath = path.resolve(dir, `.~${v4()}.yaml`);
     }
     ipcRenderer.send("add-temp-file", tempPath);
     return tempPath;


### PR DESCRIPTION
Added a check if on Mac before running `terminal` command in order to prevent misleading error message on other OSes. Also switched from deprecated `uuidv4` to `uuid.v4`. 